### PR TITLE
Fixes to SYS_READ changes in PR #727 per review. (#729)

### DIFF
--- a/src/gdbserver/semihosting.c
+++ b/src/gdbserver/semihosting.c
@@ -307,7 +307,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         int      fd;
         uint32_t buffer_len;
         void    *buffer;
-	int	 read_result;
+	ssize_t  read_result;
 
         if (mem_read(sl, r1, args, sizeof (args)) != 0 ) {
             DLOG("Semihosting SYS_READ error: "
@@ -338,20 +338,20 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         DLOG("Semihosting: read(%d, target_addr:0x%08x, %zu)\n", fd,
              buffer_address, buffer_len);
 
-        read_result = (uint32_t)read(fd, buffer, buffer_len);
+        read_result = read(fd, buffer, buffer_len);
         saved_errno = errno;
 
-        if (*ret == (uint32_t)-1) {
+        if (read_result == (uint32_t)-1) {
             *ret = buffer_len;
         } else {
-            if (mem_write(sl, buffer_address, buffer, *ret) != 0 ) {
+            if (mem_write(sl, buffer_address, buffer, read_result) != 0 ) {
                 DLOG("Semihosting SYS_READ error: "
                      "cannot write buffer to target memory\n");
                 free(buffer);
                 *ret = buffer_len;
                 return -1;
             } else {
-                *ret = buffer_len - read_result;
+                *ret = buffer_len - (uint32_t)read_result;
             }
         }
 


### PR DESCRIPTION
* Use local variable for read_result instead of *ret, and fix
calculation of *ret for EOF case.

* Found a problem when reading an odd (%4) number of bytes at the end
of a file.  fread (on stm32) get them (say 3 bytes), then askes for
more.  do_semihosting gets a read return of 0 and tries to write that.
mem_write alters the address to be aligned and overwrites then 3 bytes
from the last read.

This change simply tells mem_write to do nothing if len is 0.

* Fix Issues from Fabien-Chouteau's review of my previous patch in isue #727.

* Revert change to mem_write() so it does not confuse fixes to do_semihosting().

* Add cast to avoid warning.